### PR TITLE
richtige Verwendung des I2C read/write bits in der Grafik

### DIFF
--- a/lectures/05_Kommunikation.md
+++ b/lectures/05_Kommunikation.md
@@ -421,7 +421,7 @@ Schreiben in eines der Slave-Register
 ```ascii
 
        +-----+------------+----+     +--------------+     +--------------+     +------+
-Master |Start| Adressframe| 1  |     | Reg. Adresse |     |    Daten     |     | Stop |
+Master |Start| Adressframe| 0  |     | Reg. Adresse |     |    Daten     |     | Stop |
        +-----+------------+----+     +--------------+     +--------------+     +------+
 
                                +-----+              +-----+              +-----+
@@ -435,7 +435,7 @@ Lesen aus einem der Slave-Register
 ```ascii
 
        +-----+------------+----+     +--------------+                    +-----+------+
-Master |Start| Adressframe| 0  |     | Reg. Adresse |                    |NAKN | Stop |
+Master |Start| Adressframe| 1  |     | Reg. Adresse |                    |NAKN | Stop |
        +-----+------------+----+     +--------------+                    +-----+------+
 
                                +-----+              +-----+--------------+


### PR DESCRIPTION
Die I2C Grafik widerspricht der Erklärung davor. Andere Quellen, z. B. hier https://maxembedded.wordpress.com/2014/02/09/inter-integrated-circuits-i2c-basics/ stimmen mit der Erklärung überein: um Daten zu senden, setzt der Master das Bit auf 0, um Daten anzufordern auf 1.