### PR TITLE
Correct code example

### DIFF
--- a/exercises/00_Einfuehrung.md
+++ b/exercises/00_Einfuehrung.md
@@ -174,9 +174,9 @@ int main()
   std::cout << std::bitset<8>(PORTB) << std::endl;
 
   if (PORTB & (1 << PB0))
-       std::cout << "Bit 2 gesetzt" << std::endl;
+       std::cout << "Bit 0 gesetzt" << std::endl;
   if (!(PORTB & (1 << PB0)))
-       std::cout << "Bit 2 nicht gesetzt" << std::endl;
+       std::cout << "Bit 0 nicht gesetzt" << std::endl;
   // Ist PB0 ODER PB2 gesetzt?
   if (PORTB & ((1 << PB0) | (1 << PB2)))
      std::cout << "Bit 0 oder 2 gesetzt" << std::endl;


### PR DESCRIPTION
Correct the output line in the code example in "Prüfen eines Bits" to correctly reflect checking PB0 instead of PB2